### PR TITLE
Refactor chat into reusable components

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { Message as MessageType } from "../types/ChatTypes";
+import { Action } from "../types/mockAITypes";
+import { mockAiClient } from "../api/mockAi";
+import { FormEvent, KeyboardEvent } from "react";
+
+export const useChat = () => {
+  const [messages, setMessages] = useState<MessageType[]>([]);
+  const [messageInput, setMessageInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hideAllActions = () => {
+    setMessages((prev) => prev.map((msg) => ({ ...msg, showActions: false })));
+  };
+
+  const sendMessage = async (text: string, addUserMessage = true) => {
+    if (isLoading) return;
+    hideAllActions();
+    setIsLoading(true);
+    setError(null);
+
+    if (addUserMessage) {
+      const userMessage: MessageType = {
+        id: crypto.randomUUID(),
+        isAi: false,
+        content: text,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, userMessage]);
+    }
+
+    try {
+      const response = await mockAiClient.getResponse({ message: text });
+      const aiResponse: MessageType = {
+        id: crypto.randomUUID(),
+        isAi: true,
+        content: response.message,
+        timestamp: new Date(),
+        showActions: false,
+        actions: response.availableActions,
+      };
+      setMessages((prev) => [...prev, aiResponse]);
+      setTimeout(() => {
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === aiResponse.id ? { ...msg, showActions: true } : msg
+          )
+        );
+      }, 1000);
+    } catch (err) {
+      console.error(err);
+      setError("Une erreur est survenue. Veuillez réessayer.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSendMessage = async (
+    e: FormEvent | KeyboardEvent
+  ) => {
+    e.preventDefault();
+    if (!messageInput.trim()) return;
+    const text = messageInput;
+    setMessageInput("");
+    await sendMessage(text, true);
+  };
+
+  const handleAction = async (action: Action) => {
+    await sendMessage(action.label, false);
+  };
+
+  return {
+    messages,
+    messageInput,
+    setMessageInput,
+    isLoading,
+    error,
+    handleSendMessage,
+    handleAction,
+  };
+};
+
+export default useChat;

--- a/src/pages/Home/components/ChatAI.tsx
+++ b/src/pages/Home/components/ChatAI.tsx
@@ -1,126 +1,25 @@
-import React, { useState, useRef, useEffect } from "react";
-import { Send, Image, Instagram, Facebook, MessageCircle } from "lucide-react";
-import { Message as MessageType } from "../../../types/ChatTypes";
-import { Action } from "../../../types/mockAITypes";
-import { mockAiClient } from "../../../api/mockAi";
-import Message from "./ChatMessage";
+import React from "react";
+import MessageList from "./MessageList";
+import ChatInput from "./ChatInput";
+import QuickActions from "./QuickActions";
+import useChat from "../../../hooks/useChat";
 
 const Chat: React.FC = () => {
-  const [messages, setMessages] = useState<MessageType[]>([]);
-  const [messageInput, setMessageInput] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [showWelcome, setShowWelcome] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const messageEndRef = useRef<HTMLDivElement>(null);
-  const messagesContainerRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  const adjustTextareaHeight = () => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = "auto";
-      const newHeight = Math.min(textarea.scrollHeight, 200); // Max height of 200px
-      textarea.style.height = `${newHeight}px`;
-    }
-  };
-
-  useEffect(() => {
-    adjustTextareaHeight();
-  }, [messageInput]);
-
-  const scrollToBottom = () => {
-    messageEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter") {
-      if (e.ctrlKey) {
-        // Ctrl+Enter: insert new line
-        setMessageInput((prev) => prev + "\n");
-      } else {
-        // Enter: send message
-        e.preventDefault();
-        handleSendMessage(e);
-      }
-    }
-  };
-
-
-  const hideAllActions = () => {
-    setMessages((prev) => prev.map((msg) => ({ ...msg, showActions: false })));
-  };
-
-  const sendMessage = async (text: string, addUserMessage = true) => {
-    if (isLoading) return;
-    hideAllActions();
-    setShowWelcome(false);
-    setIsLoading(true);
-    setError(null);
-
-    let userMessage: MessageType | null = null;
-    if (addUserMessage) {
-      userMessage = {
-        id: crypto.randomUUID(),
-        isAi: false,
-        content: text,
-        timestamp: new Date(),
-      };
-      setMessages((prev) => [...prev, userMessage!]);
-    }
-
-    try {
-      const response = await mockAiClient.getResponse({ message: text });
-      const aiResponse: MessageType = {
-        id: crypto.randomUUID(),
-        isAi: true,
-        content: response.message,
-        timestamp: new Date(),
-        showActions: false,
-        actions: response.availableActions,
-      };
-
-      setMessages((prev) => [...prev, aiResponse]);
-
-      setTimeout(() => {
-        setMessages((prev) =>
-          prev.map((msg) =>
-            msg.id === aiResponse.id ? { ...msg, showActions: true } : msg
-          )
-        );
-      }, 1000);
-    } catch (err) {
-      console.error(err);
-      setError("Une erreur est survenue. Veuillez réessayer.");
-    } finally {
-      setIsLoading(false);
-      textareaRef.current?.focus();
-    }
-  };
-
-  const handleSendMessage = async (
-    e: React.FormEvent | React.KeyboardEvent
-  ) => {
-    e.preventDefault();
-    if (!messageInput.trim()) return;
-    const text = messageInput;
-    setMessageInput("");
-    await sendMessage(text, true);
-  };
-
-  const handleAction = async (action: Action) => {
-    await sendMessage(action.label, false);
-  };
+  const {
+    messages,
+    messageInput,
+    setMessageInput,
+    isLoading,
+    error,
+    handleSendMessage,
+    handleAction,
+  } = useChat();
 
   return (
     <>
-      {/* Messages */}
       <div className="flex-1 pt-16 pb-24 overflow-hidden">
         <div className="max-w-3xl mx-auto px-4">
-          {showWelcome && messages.length === 0 && (
+          {messages.length === 0 && (
             <div className="flex justify-center items-center min-h-[60vh]">
               <div className="relative w-full">
                 <img
@@ -140,117 +39,23 @@ const Chat: React.FC = () => {
             </div>
           )}
           <div
-            className={`flex flex-col space-y-6 py-6 transition-opacity duration-500 ${
-              showWelcome ? "opacity-0" : "opacity-100"
+            className={`transition-opacity duration-500 ${
+              messages.length === 0 ? "opacity-0" : "opacity-100"
             }`}
-            ref={messagesContainerRef}
           >
-            {messages.map((message) => (
-              <Message
-                key={message.id}
-                handleAction={handleAction}
-                {...message}
-              />
-            ))}
-            <div ref={messageEndRef} />
+            <MessageList messages={messages} handleAction={handleAction} />
           </div>
         </div>
       </div>
-
-      {/* Message Input */}
-      <div className="fixed bottom-0 left-0 right-0 md:pb-8">
-        <form
-          onSubmit={handleSendMessage}
-          className="sm:max-w-full md:max-w-2xl mx-auto"
-        >
-          {/* Quick Actions Carousel */}
-          <div className="px-4 mb-4 overflow-x-auto scrollbar-hide">
-            <div className="flex space-x-2 w-max">
-              <button
-                type="button"
-                onClick={() => {
-                  setMessageInput("Créer un post Instagram");
-                  textareaRef.current?.focus();
-                }}
-                className="flex items-center space-x-2 bg-white px-4 py-2.5 rounded-lg border border-gray-300 transition-colors shadow-sm whitespace-nowrap"
-              >
-                <Instagram className="w-5 h-5 text-[#1A201B]" />
-                <span className="text-sm text-[#1A201B]">
-                  Créer un post Instagram
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setMessageInput("Créer un post Facebook");
-                  textareaRef.current?.focus();
-                }}
-                className="flex items-center space-x-2 bg-white px-4 py-2.5 rounded-lg border border-gray-300 transition-colors shadow-sm whitespace-nowrap"
-              >
-                <Facebook className="w-5 h-5 text-[#1A201B]" />
-                <span className="text-sm text-[#1A201B]">
-                  Créer un post Facebook
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setMessageInput("Créer un post TikTok");
-                  textareaRef.current?.focus();
-                }}
-                className="flex items-center space-x-2 bg-white px-4 py-2.5 rounded-lg border border-gray-300 transition-colors shadow-sm whitespace-nowrap"
-              >
-                <MessageCircle className="w-5 h-5 text-[#1A201B]" />
-                <span className="text-sm text-[#1A201B]">
-                  Créer un post TikTok
-                </span>
-              </button>
-            </div>
-          </div>
-
-          {error && (
-            <p className="text-sm text-red-600 px-4 mb-2">{error}</p>
-          )}
-          {isLoading && (
-            <p className="text-sm text-gray-500 px-4 mb-2">
-              NessIA rédige...
-            </p>
-          )}
-
-          <div className="relative w-full md:mx-auto bg-white md:rounded-2xl border border-gray-300 transition-colors shadow-sm">
-            <textarea
-              ref={textareaRef}
-              value={messageInput}
-              onChange={(e) => setMessageInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Discuter avec NessIA"
-              rows={1}
-              disabled={isLoading}
-              className="resize-none w-full px-4 pt-4 pb-2 rounded-2xl bg-transparent focus:outline-none max-h-[200px] overflow-y-auto whitespace-pre-wrap"
-              style={{ minHeight: "56px" }}
-            />
-            <div className="flex items-center justify-between px-4 pb-3">
-              <button
-                type="button"
-                className="hover:bg-gray-50 rounded-lg p-2 transition-colors"
-              >
-                <Image className="w-7 h-7 text-[#1A201B]" />
-              </button>
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="bg-[#7C3AED] text-white p-[5px] rounded-md hover:bg-[#6D28D9] transition-colors shadow-sm"
-              >
-                {isLoading ? (
-                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                ) : (
-                  <Send className="w-5 h-5" />
-                )}
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
+      <ChatInput
+        value={messageInput}
+        onChange={setMessageInput}
+        onSend={handleSendMessage}
+        isLoading={isLoading}
+        error={error}
+      >
+        <QuickActions onSelect={setMessageInput} />
+      </ChatInput>
     </>
   );
 };

--- a/src/pages/Home/components/ChatInput.tsx
+++ b/src/pages/Home/components/ChatInput.tsx
@@ -1,0 +1,92 @@
+import React, { useRef, useEffect } from "react";
+import { Send, Image } from "lucide-react";
+
+interface ChatInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: (e: React.FormEvent | React.KeyboardEvent) => void;
+  isLoading: boolean;
+  error: string | null;
+  children?: React.ReactNode;
+}
+
+const ChatInput: React.FC<ChatInputProps> = ({
+  value,
+  onChange,
+  onSend,
+  isLoading,
+  error,
+  children,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustTextareaHeight = () => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = "auto";
+      const newHeight = Math.min(textarea.scrollHeight, 200);
+      textarea.style.height = `${newHeight}px`;
+    }
+  };
+
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [value]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter") {
+      if (e.ctrlKey) {
+        onChange(value + "\n");
+      } else {
+        e.preventDefault();
+        onSend(e);
+      }
+    }
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 md:pb-8">
+      <form onSubmit={onSend} className="sm:max-w-full md:max-w-2xl mx-auto">
+        <div className="px-4 mb-4 overflow-x-auto scrollbar-hide">{children}</div>
+        {error && <p className="text-sm text-red-600 px-4 mb-2">{error}</p>}
+        {isLoading && (
+          <p className="text-sm text-gray-500 px-4 mb-2">NessIA rédige...</p>
+        )}
+        <div className="relative w-full md:mx-auto bg-white md:rounded-2xl border border-gray-300 transition-colors shadow-sm">
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Discuter avec NessIA"
+            rows={1}
+            disabled={isLoading}
+            className="resize-none w-full px-4 pt-4 pb-2 rounded-2xl bg-transparent focus:outline-none max-h-[200px] overflow-y-auto whitespace-pre-wrap"
+            style={{ minHeight: "56px" }}
+          />
+          <div className="flex items-center justify-between px-4 pb-3">
+            <button
+              type="button"
+              className="hover:bg-gray-50 rounded-lg p-2 transition-colors"
+            >
+              <Image className="w-7 h-7 text-[#1A201B]" />
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="bg-[#7C3AED] text-white p-[5px] rounded-md hover:bg-[#6D28D9] transition-colors shadow-sm"
+            >
+              {isLoading ? (
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <Send className="w-5 h-5" />
+              )}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/src/pages/Home/components/MessageList.tsx
+++ b/src/pages/Home/components/MessageList.tsx
@@ -1,0 +1,28 @@
+import React, { useRef, useEffect } from "react";
+import Message from "./ChatMessage";
+import { Message as MessageType } from "../../../types/ChatTypes";
+import { Action } from "../../../types/mockAITypes";
+
+interface MessageListProps {
+  messages: MessageType[];
+  handleAction: (action: Action) => void;
+}
+
+const MessageList: React.FC<MessageListProps> = ({ messages, handleAction }) => {
+  const messageEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messageEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  return (
+    <div className="flex flex-col space-y-6 py-6">
+      {messages.map((message) => (
+        <Message key={message.id} handleAction={handleAction} {...message} />
+      ))}
+      <div ref={messageEndRef} />
+    </div>
+  );
+};
+
+export default MessageList;

--- a/src/pages/Home/components/QuickActions.tsx
+++ b/src/pages/Home/components/QuickActions.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Instagram, Facebook, MessageCircle } from "lucide-react";
+
+interface QuickActionsProps {
+  onSelect: (text: string) => void;
+}
+
+const QuickActions: React.FC<QuickActionsProps> = ({ onSelect }) => (
+  <div className="flex space-x-2 w-max">
+    <button
+      type="button"
+      onClick={() => onSelect("Créer un post Instagram")}
+      className="flex items-center space-x-2 bg-white px-4 py-2.5 rounded-lg border border-gray-300 transition-colors shadow-sm whitespace-nowrap"
+    >
+      <Instagram className="w-5 h-5 text-[#1A201B]" />
+      <span className="text-sm text-[#1A201B]">Créer un post Instagram</span>
+    </button>
+    <button
+      type="button"
+      onClick={() => onSelect("Créer un post Facebook")}
+      className="flex items-center space-x-2 bg-white px-4 py-2.5 rounded-lg border border-gray-300 transition-colors shadow-sm whitespace-nowrap"
+    >
+      <Facebook className="w-5 h-5 text-[#1A201B]" />
+      <span className="text-sm text-[#1A201B]">Créer un post Facebook</span>
+    </button>
+    <button
+      type="button"
+      onClick={() => onSelect("Créer un post TikTok")}
+      className="flex items-center space-x-2 bg-white px-4 py-2.5 rounded-lg border border-gray-300 transition-colors shadow-sm whitespace-nowrap"
+    >
+      <MessageCircle className="w-5 h-5 text-[#1A201B]" />
+      <span className="text-sm text-[#1A201B]">Créer un post TikTok</span>
+    </button>
+  </div>
+);
+
+export default QuickActions;


### PR DESCRIPTION
## Summary
- introduce `useChat` hook for chat state & API calls
- break chat UI into `MessageList`, `ChatInput`, and `QuickActions`
- simplify `ChatAI` to a presentational component using the new hook

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npx tsc --noEmit`