### PR TITLE
feat: standardize error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import {
   BrowserRouter as Router,
   Routes,
   Route,
-  Navigate,
 } from "react-router-dom";
 import { AuthProvider } from "./shared/contexts/AuthContext";
 import { AppProvider } from "./shared/contexts/AppContext";
@@ -18,6 +17,7 @@ import PostsDisplay from "./pages/Posts";
 import ChatsDisplay from "./pages/Chats";
 import FileSelectModal from "./shared/components/FileSelectModal";
 import ChatAI from "./pages/Home/components/ChatAI";
+import NotFound from "./shared/components/errors/NotFound";
 
 const App: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(true);
@@ -75,8 +75,8 @@ const App: React.FC = () => {
                 {/* Add more protected routes here */}
               </Route>
 
-              {/* Redirect to home for any other routes */}
-              <Route path="*" element={<Navigate to="/" replace />} />
+              {/* Fallback for unknown routes */}
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </div>
         </AppProvider>

--- a/src/pages/Posts/index.tsx
+++ b/src/pages/Posts/index.tsx
@@ -22,6 +22,7 @@ const PostsDisplay: React.FC = () => {
     fetchPosts,
     setSort,
     deletePost,
+    setError,
   } = usePostsStore();
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -33,10 +34,9 @@ const PostsDisplay: React.FC = () => {
       startFetchLoading();
       try {
         const userPosts = await PostsService.fetchUserPosts();
-
         fetchPosts(userPosts);
       } catch (err) {
-        console.error("Failed to load posts:", err);
+        setError(err, "Impossible de charger les publications");
       }
     };
 
@@ -77,7 +77,7 @@ const PostsDisplay: React.FC = () => {
         await db.deletePostById(postId);
         deletePost(postId);
       } catch (err) {
-        console.error("Failed to delete post:", err);
+        setError(err, "Impossible de supprimer la publication");
       }
     }
   };

--- a/src/pages/Posts/store/postsStore.ts
+++ b/src/pages/Posts/store/postsStore.ts
@@ -1,5 +1,6 @@
 import { useReducer } from "react";
 import { Post, PostsState } from "../entities/PostTypes";
+import { handleError } from "../../../shared/utils/errorHandler";
 
 type PostsAction =
   | { type: "FETCH_POSTS_START" }
@@ -127,6 +128,11 @@ export const usePostsStore = () => {
     dispatch({ type: "UPDATE_POST_STATUS", payload: { id, status } });
   };
 
+  const setError = (error: unknown, message: string) => {
+    const summary = handleError(error, message);
+    dispatch({ type: "FETCH_POSTS_ERROR", payload: summary });
+  };
+
   return {
     ...state,
     fetchPosts,
@@ -134,5 +140,6 @@ export const usePostsStore = () => {
     deletePost,
     updatePostStatus,
     startFetchLoading,
+    setError,
   };
 };

--- a/src/shared/components/errors/NotFound.tsx
+++ b/src/shared/components/errors/NotFound.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const NotFound: React.FC = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[#E7E9F2] text-center p-4">
+      <img src="/assets/nessia_logo.svg" alt="Nessia logo" className="w-24 mb-6" />
+      <h1 className="text-3xl font-semibold text-[#1A201B] mb-2">Page introuvable</h1>
+      <p className="text-gray-600 mb-6">
+        La page que vous cherchez n'existe pas.
+      </p>
+      <Link
+        to="/"
+        className="bg-[#7C3AED] text-white px-6 py-3 rounded-lg font-medium hover:bg-[#6D28D9] transition-colors"
+      >
+        Retour à l'accueil
+      </Link>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/src/shared/contexts/AppContext.tsx
+++ b/src/shared/contexts/AppContext.tsx
@@ -5,11 +5,14 @@ import {
   AppState,
   AppAction,
 } from "../store/AppReducer";
+import { handleError } from "../utils/errorHandler";
 
 // Context
 interface AppContextType {
   state: AppState;
   dispatch: React.Dispatch<AppAction>;
+  setGlobalError: (error: unknown, message: string) => void;
+  clearGlobalError: () => void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -20,8 +23,17 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const [state, dispatch] = useReducer(appReducer, initialState);
 
+  const setGlobalError = (error: unknown, message: string) => {
+    const summary = handleError(error, message);
+    dispatch({ type: "SET_GLOBAL_ERROR", payload: summary });
+  };
+
+  const clearGlobalError = () => dispatch({ type: "CLEAR_GLOBAL_ERROR" });
+
   return (
-    <AppContext.Provider value={{ state, dispatch }}>
+    <AppContext.Provider
+      value={{ state, dispatch, setGlobalError, clearGlobalError }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/src/shared/store/AppReducer.ts
+++ b/src/shared/store/AppReducer.ts
@@ -22,6 +22,7 @@ interface ChatState {
 export interface AppState {
   post: PostState;
   chat: ChatState;
+  error: string | null;
 }
 
 // Action Types
@@ -49,7 +50,11 @@ export type ChatAction =
   | { type: "SHOW_QUICK_ACTIONS" }
   | { type: "RESET_CHAT" };
 
-export type AppAction = PostAction | ChatAction;
+export type AppAction =
+  | PostAction
+  | ChatAction
+  | { type: "SET_GLOBAL_ERROR"; payload: string }
+  | { type: "CLEAR_GLOBAL_ERROR" };
 
 // Initial State
 export const initialState: AppState = {
@@ -72,6 +77,7 @@ export const initialState: AppState = {
     error: null,
     showQuickActions: true,
   },
+  error: null,
 };
 
 // Reducer
@@ -265,6 +271,18 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
     case "RESET_CHAT":
       return {
         ...initialState,
+      };
+
+    case "SET_GLOBAL_ERROR":
+      return {
+        ...state,
+        error: action.payload,
+      };
+
+    case "CLEAR_GLOBAL_ERROR":
+      return {
+        ...state,
+        error: null,
       };
 
     default:

--- a/src/shared/utils/errorHandler.ts
+++ b/src/shared/utils/errorHandler.ts
@@ -1,0 +1,8 @@
+import { toast } from "react-hot-toast";
+
+export const handleError = (error: unknown, message: string) => {
+  console.error(error);
+  toast.error(message);
+  return message;
+};
+


### PR DESCRIPTION
## Summary
- add error handler utility and global error state
- notify errors using toast and console
- add not found page routing

## Testing
- `npm test` (fails: Expected 0 arguments but got 1)
- `npm run lint` (fails: Cannot read properties of undefined (reading 'allowShortCircuit'))


------
https://chatgpt.com/codex/tasks/task_b_689477876f5483329b25f29d7dcf6f52