### PR TITLE
Scope data queries to active company

### DIFF
--- a/src/pages/Chats/index.tsx
+++ b/src/pages/Chats/index.tsx
@@ -15,7 +15,7 @@ import { useApp } from "../../shared/contexts/AppContext";
 const ChatsDisplay: React.FC = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { dispatch } = useApp();
+  const { dispatch, state } = useApp();
 
   const {
     conversations,
@@ -38,7 +38,9 @@ const ChatsDisplay: React.FC = () => {
       if (user?.id) {
         fetchChats([]); // Start loading state
         try {
-          const userChats = await db.getAllChats();
+          const userChats = await db.getAllChats(
+            state.currentCompany?.id as string
+          );
           const userChatsFormated = formatChatsforUi(userChats); // A bouger dans les services
 
           fetchChats(userChatsFormated);
@@ -103,7 +105,10 @@ const ChatsDisplay: React.FC = () => {
       )
     ) {
       try {
-        const response = await db.deleteChatById(chatId);
+        const response = await db.deleteChatById(
+          chatId,
+          state.currentCompany?.id as string
+        );
         console.log(response);
         deleteChat(chatId);
       } catch (err) {

--- a/src/pages/PostEditor/index.tsx
+++ b/src/pages/PostEditor/index.tsx
@@ -19,7 +19,10 @@ const PostEditor: React.FC = () => {
       // Fetch post data by ID when postId is available
       const fetchPostData = async () => {
         try {
-          const data = await db.getPostById(postId);
+          const data = await db.getPostById(
+            postId,
+            state.currentCompany?.id as string
+          );
           console.log(data);
 
           dispatch({
@@ -43,7 +46,11 @@ const PostEditor: React.FC = () => {
     try {
       const formatedPost = formatPostToDb(postData);
       console.log(formatedPost);
-      await db.updatePostById(postId!, formatedPost);
+      await db.updatePostById(
+        postId!,
+        formatedPost,
+        state.currentCompany?.id as string
+      );
 
       dispatch({ type: "SAVE_POST_SUCCESS" });
     } catch (err) {

--- a/src/pages/Posts/index.tsx
+++ b/src/pages/Posts/index.tsx
@@ -6,12 +6,14 @@ import { usePostsStore } from "./store/postsStore";
 import { PostsService } from "./services/postsService";
 import { Post } from "./entities/PostTypes";
 import { db } from "../../shared/services/db";
+import { useApp } from "../../shared/contexts/AppContext";
 import PostsHeader from "./components/PostsHeader";
 import PostsGrid from "./components/PostsGrid";
 
 const PostsDisplay: React.FC = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { state } = useApp();
   const {
     posts,
     isLoading,
@@ -33,7 +35,9 @@ const PostsDisplay: React.FC = () => {
     const loadPosts = async () => {
       startFetchLoading();
       try {
-        const userPosts = await PostsService.fetchUserPosts();
+        const userPosts = await PostsService.fetchUserPosts(
+          state.currentCompany?.id as string
+        );
         fetchPosts(userPosts);
       } catch (err) {
         setError(err, "Impossible de charger les publications");
@@ -74,7 +78,7 @@ const PostsDisplay: React.FC = () => {
       window.confirm("Êtes-vous sûr de vouloir supprimer cette publication ?")
     ) {
       try {
-        await db.deletePostById(postId);
+        await db.deletePostById(postId, state.currentCompany?.id as string);
         deletePost(postId);
       } catch (err) {
         setError(err, "Impossible de supprimer la publication");

--- a/src/pages/Posts/services/postsService.ts
+++ b/src/pages/Posts/services/postsService.ts
@@ -18,9 +18,9 @@ const mapPost = (data: any): Post => {
 };
 
 export class PostsService {
-  static async fetchUserPosts(): Promise<Post[]> {
+  static async fetchUserPosts(companyId: string): Promise<Post[]> {
     // Simulate API call delay
-    const posts = await db.getAllPosts();
+    const posts = await db.getAllPosts(companyId);
     const mappedPosts = posts.map(mapPost);
 
     // For demo purposes, always return mock data regardless of userId

--- a/src/shared/components/DeleteChatModal.tsx
+++ b/src/shared/components/DeleteChatModal.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { X, Trash2, AlertTriangle } from "lucide-react";
 import { db } from "../services/db";
 import toast from "react-hot-toast";
+import { useApp } from "../contexts/AppContext";
 
 interface DeleteChatModalProps {
   isOpen: boolean;
@@ -20,6 +21,7 @@ const DeleteChatModal: React.FC<DeleteChatModalProps> = ({
   onDeleteConfirm,
 }) => {
   const [isLoading, setIsLoading] = React.useState(false);
+  const { state } = useApp();
   const modalRef = useRef<HTMLDivElement>(null);
 
   // Close modal when clicking outside
@@ -60,7 +62,7 @@ const DeleteChatModal: React.FC<DeleteChatModalProps> = ({
     setIsLoading(true);
     
     try {
-      await db.deleteChatById(chatId);
+      await db.deleteChatById(chatId, state.currentCompany?.id as string);
       onDeleteConfirm();
       toast.success("Conversation supprimée avec succès");
       onClose();

--- a/src/shared/components/FloatingActionButton.tsx
+++ b/src/shared/components/FloatingActionButton.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { MessageCircle, FileText, Loader2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { db } from "../services/db"; // services de base de données globaux
+import { useApp } from "../contexts/AppContext";
 
 interface FloatingActionButtonProps {
   type: "post" | "chat";
@@ -19,6 +20,7 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [associatedId, setAssociatedId] = useState<string | null>(null); // gare en mémoire l'id associé (post ou chat) pour la navigation
   const navigate = useNavigate();
+  const { state } = useApp();
 
   useEffect(() => {
     const checkExistence = async () => {
@@ -26,7 +28,10 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
       try {
         if (type === "post") {
           // Check if associated chat exists and get his ID
-          const post = await db.getPostById(id);
+            const post = await db.getPostById(
+              id,
+              state.currentCompany?.id as string
+            );
           const associatedChatId = post?.session?.id || null;
 
           if (associatedChatId) {
@@ -38,7 +43,10 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
         } else if (type === "chat") {
           // Check if chat exists and get associated post ID
           // TODO : aller chercher si le chat a un post associé
-          const chat = await db.getChatById(id);
+            const chat = await db.getChatById(
+              id,
+              state.currentCompany?.id as string
+            );
           const associatedPostId = chat.post ? chat.post.id : null;
 
           if (associatedPostId) {

--- a/src/shared/components/RenameChatModal.tsx
+++ b/src/shared/components/RenameChatModal.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { X, Edit } from "lucide-react";
 import { db } from "../services/db";
 import toast from "react-hot-toast";
+import { useApp } from "../contexts/AppContext";
 
 interface RenameChatModalProps {
   isOpen: boolean;
@@ -23,6 +24,7 @@ const RenameChatModal: React.FC<RenameChatModalProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { state } = useApp();
 
   // Reset title when modal opens
   useEffect(() => {
@@ -86,7 +88,11 @@ const RenameChatModal: React.FC<RenameChatModalProps> = ({
     setIsLoading(true);
     
     try {
-      await db.renameChatById(chatId, newTitle.trim());
+      await db.renameChatById(
+        chatId,
+        newTitle.trim(),
+        state.currentCompany?.id as string
+      );
       onRenameConfirm(newTitle.trim());
       toast.success("Conversation renommée avec succès");
       onClose();

--- a/src/shared/components/layouts/BurgerMenu.tsx
+++ b/src/shared/components/layouts/BurgerMenu.tsx
@@ -40,7 +40,7 @@ interface MenuSection {
 }
 
 const BurgerMenu: React.FC<BurgerMenuProps> = ({ isOpen, onClose }) => {
-  const { dispatch } = useApp();
+  const { dispatch, state } = useApp();
   const { user } = useAuth();
   const { conversations, fetchChats } = useChatsStore();
   const { chatId: currentChatId } = useParams();
@@ -63,7 +63,9 @@ const BurgerMenu: React.FC<BurgerMenuProps> = ({ isOpen, onClose }) => {
     const loadRecentChats = async () => {
       if (isOpen && conversations.length === 0) {
         try {
-          const userChats = await db.getAllChats();
+          const userChats = await db.getAllChats(
+            state.currentCompany?.id as string
+          );
           const userChatsFormated = formatChatsforUi(userChats);
           fetchChats(userChatsFormated);
         } catch (err) {

--- a/src/shared/services/db.ts
+++ b/src/shared/services/db.ts
@@ -35,7 +35,7 @@ export const db = {
     }
   },
 
-  async getAllPosts() {
+  async getAllPosts(companyId: string) {
     try {
       const { data, error } = await supabaseClient
         .from("post")
@@ -47,7 +47,7 @@ export const db = {
                 media ( url )
             `
         )
-        .eq("company_id", 1)
+        .eq("company_id", companyId)
         .order("created_at", { ascending: false })
         .order("url", { ascending: false, referencedTable: "media" });
 
@@ -60,7 +60,7 @@ export const db = {
     }
   },
 
-  async getPostById(id: string) {
+  async getPostById(id: string, companyId: string) {
     try {
       const { data, error } = await supabaseClient
         .from("post")
@@ -72,6 +72,7 @@ export const db = {
             `
         )
         .eq("id", id)
+        .eq("company_id", companyId)
         .order("url", { ascending: false, referencedTable: "media" })
         .single();
 
@@ -84,13 +85,13 @@ export const db = {
     }
   },
 
-  async deletePostById(id: string) {
+  async deletePostById(id: string, companyId: string) {
     try {
       const { data, error } = await supabaseClient
         .from("post")
         .delete()
         .eq("id", id)
-        .eq("company_id", 1);
+        .eq("company_id", companyId);
 
       if (error) throw error;
 
@@ -103,14 +104,15 @@ export const db = {
 
   async updatePostById(
     id: string,
-    { content, hashtags }: { content: string; hashtags: string }
+    { content, hashtags }: { content: string; hashtags: string },
+    companyId: string
   ) {
     try {
       const { data, error } = await supabaseClient
         .from("post")
         .update({ content_text: content, hashtags: hashtags })
         .eq("id", id)
-        .eq("company_id", 1)
+        .eq("company_id", companyId)
         .select();
 
       if (error) throw error;
@@ -122,7 +124,7 @@ export const db = {
     }
   },
 
-  async getAllChats() {
+  async getAllChats(companyId: string) {
     try {
       const { data, error } = await supabaseClient
         .from("session")
@@ -135,7 +137,7 @@ export const db = {
           )
           `
         )
-        .eq("company_id", 1)
+        .eq("company_id", companyId)
         .not("summary", "is", null)
         .limit(20)
         .order("created_at", { ascending: false });
@@ -149,7 +151,7 @@ export const db = {
     }
   },
 
-  async getChatById(sessionId: string) {
+  async getChatById(sessionId: string, companyId: string) {
     try {
       // Récupère la session et tous ses messages associés, triés par date
       const { data, error } = await supabaseClient
@@ -170,6 +172,7 @@ export const db = {
         `
         )
         .eq("id", sessionId)
+        .eq("company_id", companyId)
         .single();
 
       if (error) throw error;
@@ -189,7 +192,7 @@ export const db = {
     }
   },
 
-  async deleteChatById(id: string) {
+  async deleteChatById(id: string, companyId: string) {
     /*
     Attention. Par effet cascade en supprimant une session
     on supprime a minima le post et tous les messages associés
@@ -200,7 +203,7 @@ export const db = {
         .from("session")
         .delete()
         .eq("id", id)
-        .eq("company_id", 1);
+        .eq("company_id", companyId);
 
       return response;
     } catch (err) {
@@ -209,13 +212,13 @@ export const db = {
     }
   },
 
-  async renameChatById(id: string, newName: string) {
+  async renameChatById(id: string, newName: string, companyId: string) {
     try {
       const { data, error } = await supabaseClient
         .from("session")
         .update({ title: newName })
         .eq("id", id)
-        .eq("company_id", 1)
+        .eq("company_id", companyId)
         .select();
 
       console.log(data);


### PR DESCRIPTION
## Summary
- Pass `companyId` to post and chat db helpers and filter queries by this id
- Forward current company id in posts, chats and related modals when calling the db
- Ensure helper calls for post/chat lookups also include company scoping

## Testing
- `npm test` *(fails: Expected 0 arguments, but got 1)*
- `npm run lint` *(fails: 44 problems (36 errors, 8 warnings))*

------
https://chatgpt.com/codex/tasks/task_b_689b391e4e188332b4816d7f8a3e487c